### PR TITLE
randomly dropping packets

### DIFF
--- a/base.js
+++ b/base.js
@@ -57,8 +57,14 @@ class Node {
       return fn(ts)
     })
   }
-  sleep (sleeping) {
-    this.sleeping = sleeping === true
+  sleep (sleeping, ts) {
+    if(ts) {
+      this.queue.push({ts: this.queue.ts + ts, fn: ()=>{
+        this.sleeping = sleeping === true
+      }})
+    }
+    else
+      this.sleeping = sleeping === true
   }
 }
 
@@ -133,6 +139,10 @@ class Network extends Node {
   iterateUntil (until_ts) {
     this.init(this.queue.ts)
     this.queue.drain(until_ts)
+  }
+  iterateMore (until_ts) {
+    this.init(this.queue.ts)
+    this.queue.drain(this.queue.ts + until_ts)
   }
 /*  delay (wait, fn) {
     if(wait <= 0) throw new Error('delay must be positive, was:'+wait)

--- a/base.js
+++ b/base.js
@@ -67,9 +67,7 @@ class Node {
   }
   sleep (sleeping, ts) {
     if(ts) {
-      this.queue.push({ts: this.queue.ts + ts, fn: ()=>{
-        this.sleeping = sleeping === true
-      }})
+      this.network.timer(ts, 0, ()=>{ this.sleeping = sleeping === true })
     }
     else
       this.sleeping = sleeping === true

--- a/test/index.js
+++ b/test/index.js
@@ -783,3 +783,65 @@ test('create node with object', function (t) {
 
   t.end()
 })
+
+test('drop packets randomly', function (t) {
+//  t.plan(2)
+//  console.log(network)
+  var a = 'a.a.a.a'
+  var b = 'b.b.b.b'
+  var received = 0
+  var _ts = 0
+  function createBPeer (send, timer, self, ts) {
+    for(var i = 0; i < 1000; i++)
+      send('hello', {address: a, port: 10}, 1)
+    return function onMessage (msg, addr, port, ts) {
+    }
+  }
+  //echo the received message straight back.
+  function createAPeer (send) {
+    return function onMessage (msg, addr, port) {
+      received ++
+    }
+  }
+
+  network.dropProb = 0.1
+  network.add(a,  new Node(createAPeer))
+  network.add(b,  new Node(createBPeer))
+  network.iterate(-1)
+  console.log(received)
+  t.ok(received > 850, 'at least 850')
+  t.ok(received < 950, 'less than 950')
+  t.end()
+})
+
+test('drop packets randomly, per node', function (t) {
+//  t.plan(2)
+//  console.log(network)
+  var a = 'a.a.a.a'
+  var b = 'b.b.b.b'
+  var received = 0
+  var _ts = 0
+  function createBPeer (send, timer, self, ts) {
+    for(var i = 0; i < 1000; i++)
+      send('hello', {address: a, port: 10}, 1)
+    return function onMessage (msg, addr, port, ts) {
+    }
+  }
+  //echo the received message straight back.
+  function createAPeer (send) {
+    return function onMessage (msg, addr, port) {
+      received ++
+    }
+  }
+
+  network.dropProb = 0
+  var node_b = new Node(createBPeer)
+  node_b.dropProb = 0.5
+  network.add(a,  new Node(createAPeer))
+  network.add(b,  node_b)
+  network.iterate(-1)
+  console.log(received)
+  t.ok(received > 450, 'at least 850')
+  t.ok(received < 550, 'less than 950')
+  t.end()
+})

--- a/test/index.js
+++ b/test/index.js
@@ -712,6 +712,39 @@ test('sleeping while receiving', function (t) {
 
 })
 
+test('schedule sleep while receiving', function (t) {
+  var network = new Network()
+  var received = []
+  var n = 0
+  var addr = {address: '5.6.7.8', port:1234}
+  var echo_node = new Node(function (send, timer) {
+    timer(100, 100, (ts)=>{
+      console.log("SEND!", ts)
+      send('hello_'+(++n)+'__'+(ts-1), addr, 1234)
+    })
+    return function (msg, addr, port) {
+    }
+  })
+  network.add('1.2.3.4', echo_node)
+  var node = new Node(function (send, timer) {
+    return function (msg) {
+      received.push(msg)
+    }
+  })
+  network.add('5.6.7.8', node)
+
+  node.sleep(true, 250)
+  node.sleep(false, 750)
+
+  network.iterateUntil(1000)
+
+  t.deepEqual(received, ['hello_1__100', 'hello_2__200', 'hello_8__800', 'hello_9__900'])
+
+  t.end()
+
+})
+
+
 test('nat timeout', function (t) {
   var network = new Network()
   var received = []


### PR DESCRIPTION
add a `dropProb` property to simulate dropped packets. both Network and Node can have their own dropProb property so it's possible to model less reliable peers alongside more reliable ones. 