### PR TITLE
log dropped packets like messages

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -3,3 +3,5 @@ var DEBUG = +(process.env.DEBUG)
 module.exports = DEBUG ? function (level, ...args) {
     if(level <= DEBUG) console.log(...args)
 } : function () {}
+
+module.exports.level = DEBUG


### PR DESCRIPTION
logging that a packet is dropped makes it much easier to see which dropped packets may be causing a test failure!

it looks like this, in the same format as the MSG logs, for easy greppability
```
DROP 52.82.125.39:3456->148.225.206.179:3456 {"type":"pong","id":... 1.5816622760612518
DROP 52.82.125.39:3456->73.148.67.31:3456 {"type":"error","id"... 1.6193485306575894
DROP 73.148.67.31:3456->37.144.4.209:3456 {"type":"join","id":... 2.17873499635607
DROP 148.225.206.179:3456->37.144.4.209:3456 {"type":"join","id":... 3.116866670316085
DROP 73.148.67.31:3456->148.225.206.179:3456 {"type":"pong","id":... 3.9327465703245252
```